### PR TITLE
Fix keyword search

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,6 @@ When browsed for python, some of the results are as shown below.
 ### TODOs :
 + Make the code run faster.
 + Making it look better.
-+ Remove multiple results.
 + Change the default colors.
 
 ### Contributing :

--- a/scrape.py
+++ b/scrape.py
@@ -57,7 +57,7 @@ def scrape():
         )
 
         for tag in tags:
-            if user_pref in tag.text:
+            if user_pref == tag.text.lower():
                 number = no_of_times(org_name)
                 print "Name: " + org_name
                 print "Link: " + org_link

--- a/scrape.py
+++ b/scrape.py
@@ -51,10 +51,11 @@ def scrape():
         response = requests.get(org_link)
         html = response.content
         soup = BeautifulSoup(html)
-        tags = soup.findAll('li', attrs={
-                'class': 'organization__tag organization__tag--technology'
-                }
-            )
+        tags = soup.findAll(
+            'li',
+            attrs={'class': 'organization__tag organization__tag--technology'}
+        )
+
         for tag in tags:
             if user_pref in tag.text:
                 number = no_of_times(org_name)


### PR DESCRIPTION
It resolves finding javascript results as positive when searching with `java` as search term. Also, getting multiple results problem will be resolved.

You can add `print user_pref, tag.text` to 61th line for debug. On current master, you'll see that it catches both java and javascript results. With this fix, it only catches exact matches.