### PR TITLE
Adds proxy support and adds colored output

### DIFF
--- a/resources/pyterm_colors.py
+++ b/resources/pyterm_colors.py
@@ -1,0 +1,43 @@
+class color:
+
+# Part one: To be used as :
+# from pyterm_colors import * 
+# print color.red + "your-text"
+
+    default = '\033[39m'
+    black = '\033[30m'
+    red = '\033[31m'
+    green = '\033[32m'
+    yellow = '\033[33m'
+    blue = '\033[34m'
+    magenta = '\033[35m'
+    cyan = '\033[36m'
+    white = '\033[00m'
+
+# Part two: To be used as :
+# from pyterm_colors import *
+# c = color()
+# c.setc("green")
+
+    def setc(self, colo):
+        colo = colo.lower()
+        if colo == "default":
+            print self.default
+        elif colo == "black":
+            print self.black
+        elif colo == "red":
+    	    print self.red
+        elif colo == "green":
+             print self.green
+        elif colo == "yellow":
+            print self.yellow
+        elif colo == "blue":
+            print self.blue
+        elif colo == "magenta":
+            print self.magenta
+        elif colo == "cyan":
+            print self.cyan
+        elif colo == "white":
+            print self.white
+        else:
+	    print self.red

--- a/scrape.py
+++ b/scrape.py
@@ -4,6 +4,8 @@ from BeautifulSoup import BeautifulSoup
 import signal
 import sys
 import os
+from resources import pyterm_colors
+import warnings
 
 url = "https://summerofcode.withgoogle.com/archive/2016/organizations/"
 default = "https://summerofcode.withgoogle.com"
@@ -18,14 +20,20 @@ o2013 = open(os.path.join(dir_path, '2013.txt'), 'r').read().split('\n')
 o2014 = open(os.path.join(dir_path, '2014.txt'), 'r').read().split('\n')
 o2015 = open(os.path.join(dir_path, '2015.txt'), 'r').read().split('\n')
 
-#For proxy support
+# For proxy support
 proxies = {
 	'http': os.environ['http_proxy'],
 	'https': os.environ['https_proxy'],
 }
 
+# For colored output
+color = pyterm_colors.color()
+
+# To avoid warning messages
+warnings.filterwarnings("ignore")
+
 def signal_handler(signal, frame):
-    confirmation = raw_input("Really want to exit (y/n)? ")
+    confirmation = raw_input(color.red + "Really want to exit (y/n)? " + color.default)
     confirmation.replace(" ", "")
     confirmation = confirmation.lower()
     if confirmation == "y" or confirmation == "yes":
@@ -38,10 +46,11 @@ signal.signal(signal.SIGINT, signal_handler)
 
 
 def scrape():
-    user_pref = raw_input("Enter a technology of preference: ")
+    user_pref = raw_input(color.yellow + "Enter a technology of preference: " + color.default)
     user_pref = user_pref.lower()
     user_pref.replace(" ", "")
     count = 0
+    print
 
     response = requests.get(url, proxies=proxies)
     html = response.content
@@ -63,13 +72,13 @@ def scrape():
         for tag in tags:
             if user_pref in tag.text:
                 number = no_of_times(org_name)
-                print "Name: " + org_name
-                print "Link: " + org_link
-                print "No. of times in GSoC: " + str(number + 1) + '\n'
+                print color.default + "Name: " + color.cyan + org_name
+                print color.default + "Link: " + color.blue + org_link
+                print color.default + "No. of times in GSoC: " + color.yellow + str(number + 1) + '\n' + color.default
                 count += 1
 
     if count == 0:
-        print "Enter a valid technology name."
+        print color.red + "Enter a valid technology name." + color.default
 
 
 def no_of_times_before_2016(org_name):

--- a/scrape.py
+++ b/scrape.py
@@ -24,14 +24,14 @@ o2015 = open(os.path.join(dir_path, '2015.txt'), 'r').read().split('\n')
 has_proxy = False
 proxies = {}
 try:
-	proxies = {
-		'http': os.environ['http_proxy'],
-		'https': os.environ['https_proxy'],
-	}
-	has_proxy = True
-	print "Proxy detected\n"
+    proxies = {
+        'http': os.environ['http_proxy'],
+        'https': os.environ['https_proxy'],
+    }
+    has_proxy = True
+    print "Proxy detected\n"
 except KeyError:
-	pass
+    pass
 
 # For colored output
 color = pyterm_colors.color()

--- a/scrape.py
+++ b/scrape.py
@@ -21,10 +21,17 @@ o2014 = open(os.path.join(dir_path, '2014.txt'), 'r').read().split('\n')
 o2015 = open(os.path.join(dir_path, '2015.txt'), 'r').read().split('\n')
 
 # For proxy support
-proxies = {
-	'http': os.environ['http_proxy'],
-	'https': os.environ['https_proxy'],
-}
+has_proxy = False
+proxies = {}
+try:
+	proxies = {
+		'http': os.environ['http_proxy'],
+		'https': os.environ['https_proxy'],
+	}
+	has_proxy = True
+	print "Proxy detected\n"
+except KeyError:
+	pass
 
 # For colored output
 color = pyterm_colors.color()
@@ -52,7 +59,7 @@ def scrape():
     count = 0
     print
 
-    response = requests.get(url, proxies=proxies)
+    response = requests.get(url, proxies=proxies) if has_proxy else requests.get(url)
     html = response.content
 
     soup = BeautifulSoup(html)
@@ -62,7 +69,7 @@ def scrape():
         link = org.find('a', attrs={'class': 'organization-card__link'})
         org_name = org['aria-label']
         org_link = default + link['href']
-        response = requests.get(org_link, proxies=proxies)
+        response = requests.get(org_link, proxies=proxies) if has_proxy else requests.get(org_link)
         html = response.content
         soup = BeautifulSoup(html)
         tags = soup.findAll('li', attrs={
@@ -85,7 +92,7 @@ def no_of_times_before_2016(org_name):
     count = 0
     for i in range(2009, 2016):
         year_url = prev_def_url + str(i)
-        response = requests.get(year_url, proxies=proxies)
+        response = requests.get(year_url, proxies=proxies) if has_proxy else requests.get(year_url)
         html = response.content
         soup = BeautifulSoup(html)
         orgs = soup.findAll('li', attrs={
@@ -102,7 +109,7 @@ def no_of_times_before_2016(org_name):
 
 def orgs_of_an_year(year):
     year_url = prev_def_url + year
-    response = requests.get(year_url, proxies=proxies)
+    response = requests.get(year_url, proxies=proxies) if has_proxy else requests.get(year_url)
     html = response.content
     soup = BeautifulSoup(html)
     orgs = soup.findAll('li', attrs={

--- a/scrape.py
+++ b/scrape.py
@@ -18,6 +18,11 @@ o2013 = open(os.path.join(dir_path, '2013.txt'), 'r').read().split('\n')
 o2014 = open(os.path.join(dir_path, '2014.txt'), 'r').read().split('\n')
 o2015 = open(os.path.join(dir_path, '2015.txt'), 'r').read().split('\n')
 
+#For proxy support
+proxies = {
+	'http': os.environ['http_proxy'],
+	'https': os.environ['https_proxy'],
+}
 
 def signal_handler(signal, frame):
     confirmation = raw_input("Really want to exit (y/n)? ")
@@ -38,7 +43,7 @@ def scrape():
     user_pref.replace(" ", "")
     count = 0
 
-    response = requests.get(url)
+    response = requests.get(url, proxies=proxies)
     html = response.content
 
     soup = BeautifulSoup(html)
@@ -48,7 +53,7 @@ def scrape():
         link = org.find('a', attrs={'class': 'organization-card__link'})
         org_name = org['aria-label']
         org_link = default + link['href']
-        response = requests.get(org_link)
+        response = requests.get(org_link, proxies=proxies)
         html = response.content
         soup = BeautifulSoup(html)
         tags = soup.findAll('li', attrs={
@@ -71,7 +76,7 @@ def no_of_times_before_2016(org_name):
     count = 0
     for i in range(2009, 2016):
         year_url = prev_def_url + str(i)
-        response = requests.get(year_url)
+        response = requests.get(year_url, proxies=proxies)
         html = response.content
         soup = BeautifulSoup(html)
         orgs = soup.findAll('li', attrs={
@@ -88,7 +93,7 @@ def no_of_times_before_2016(org_name):
 
 def orgs_of_an_year(year):
     year_url = prev_def_url + year
-    response = requests.get(year_url)
+    response = requests.get(year_url, proxies=proxies)
     html = response.content
     soup = BeautifulSoup(html)
     orgs = soup.findAll('li', attrs={


### PR DESCRIPTION
Given that the person has exported $http_proxy and $https_proxy (which they need to if they are using Internet over a proxy server), their proxy settings will be used by requests. The program won't run without this.

Please try this on a non-proxy Internet connection.